### PR TITLE
Recover buttons.tcl example

### DIFF
--- a/layout/buttons.tcl
+++ b/layout/buttons.tcl
@@ -2,41 +2,24 @@
 
 # ZetCode Tcl/Tk tutorial
 #
-# In this script, we use the grid
+# In this script, we use the pack
 # manager to place two buttons in 
 # bottom-right corner of the window
 #
 # Author: Jan Bodnar
 # Website: www.zetcode.com
 
-
-frame .fr -padx 5 -pady 5
+frame .fr
 pack .fr -fill both -expand 1
 
-label .fr.lbl -text Windows
-grid .fr.lbl -sticky w -pady 4 -padx 5
-        
-text .fr.area
-grid .fr.area -row 1 -column 0 -columnspan 2 \
-    -rowspan 4 -padx 5 -sticky ewsn 
+frame .fr.pnl -relief raised -borderwidth 1
+pack .fr.pnl -fill both -expand 1
 
-ttk::button .fr.act -text Activate
-grid .fr.act -row 1 -column 3
+ttk::button .fr.cb -text "Close"
+pack .fr.cb -padx 5 -pady 5 -side right
 
-ttk::button .fr.cls -text Close
-grid .fr.cls -row 2 -column 3 -pady 4
+ttk::button .fr.ok -text "OK"
+pack .fr.ok -side right
 
-ttk::button .fr.hlp -text Help
-grid .fr.hlp -row 5 -column 0 -padx 5
-
-ttk::button .fr.ok -text OK
-grid .fr.ok -row 5 -column 3
-
-grid columnconfigure .fr 1 -weight 1
-grid columnconfigure .fr 3 -pad 7
-
-grid rowconfigure .fr 3 -weight 1
-grid rowconfigure .fr 5 -pad 7
-
-wm title . "Windows" 
+wm title . "Buttons" 
 wm geometry . 350x300+300+300


### PR DESCRIPTION
Seems like there was a little mishap and the buttons.tcl example script body got replaced by the one from layout/windows.tcl. Think this restores the example.